### PR TITLE
Add support for Community Parts Titles

### DIFF
--- a/GameData/Labradoodle/Localization/en-us.cfg
+++ b/GameData/Labradoodle/Localization/en-us.cfg
@@ -3,6 +3,7 @@ Localization
 	en-us
 	{
 		#LOC_Labradoodle_labrador-engine_title = RE-L20 "Labrador" Liquid Fuel Engine
+  		#LOC_Labradoodle_labrador-engine_title-CPT RE-B20 "Labrador" Liquid Fuel Engine
 		#LOC_Labradoodle_labrador-engine_description = A mid-range multi-nozzle engine designed for upper stages, fitting neatly between the performance of the Poodle and the Skipper.
 		#LOC_Labradoodle_labrador-engine_tags = lander orbit (labrador propuls rocket
 	}

--- a/GameData/Labradoodle/Localization/en-us.cfg
+++ b/GameData/Labradoodle/Localization/en-us.cfg
@@ -3,7 +3,7 @@ Localization
 	en-us
 	{
 		#LOC_Labradoodle_labrador-engine_title = RE-L20 "Labrador" Liquid Fuel Engine
-  		#LOC_Labradoodle_labrador-engine_title-CPT = RE-B20 "Labrador" Liquid Fuel Engine
+  		#LOC_Labradoodle_labrador-engine_title_CPT = RE-B20 "Labrador" Liquid Fuel Engine
 		#LOC_Labradoodle_labrador-engine_description = A mid-range multi-nozzle engine designed for upper stages, fitting neatly between the performance of the Poodle and the Skipper.
 		#LOC_Labradoodle_labrador-engine_tags = lander orbit (labrador propuls rocket
 	}

--- a/GameData/Labradoodle/Localization/en-us.cfg
+++ b/GameData/Labradoodle/Localization/en-us.cfg
@@ -3,7 +3,7 @@ Localization
 	en-us
 	{
 		#LOC_Labradoodle_labrador-engine_title = RE-L20 "Labrador" Liquid Fuel Engine
-  		#LOC_Labradoodle_labrador-engine_title-CPT RE-B20 "Labrador" Liquid Fuel Engine
+  		#LOC_Labradoodle_labrador-engine_title-CPT = RE-B20 "Labrador" Liquid Fuel Engine
 		#LOC_Labradoodle_labrador-engine_description = A mid-range multi-nozzle engine designed for upper stages, fitting neatly between the performance of the Poodle and the Skipper.
 		#LOC_Labradoodle_labrador-engine_tags = lander orbit (labrador propuls rocket
 	}

--- a/GameData/Labradoodle/Patches/labrador-engine-CPT.cfg
+++ b/GameData/Labradoodle/Patches/labrador-engine-CPT.cfg
@@ -2,4 +2,5 @@
 // In CPT, the 'Poodle' is labeled as 'RE-B10' instead of its stock name 'RE-L10', so the naming order gets messed up when used with CPT
 // This patch adds consistency to the 'Labrador' when CPT is installed
 
-@PART[labrador-engine]:FOR[z_Labradoodle]:NEEDS[002_CommunityPartsTitles]	@title = #LOC_Labradoodle_labrador-engine_title_CPT }		// RE-B20 "Labrador" Liquid Fuel Engine
+@PART[labrador-engine]:NEEDS[002_CommunityPartsTitles]:FOR[z_Labradoodle]	
+{	@title = #LOC_Labradoodle_labrador-engine_title_CPT 	}		// RE-B20 "Labrador" Liquid Fuel Engine

--- a/GameData/Labradoodle/Patches/labrador-engine-CPT.cfg
+++ b/GameData/Labradoodle/Patches/labrador-engine-CPT.cfg
@@ -1,0 +1,5 @@
+// Add support for Community Parts Titles
+// In CPT, the 'Poodle' is labeled as 'RE-B10' instead of its stock name 'RE-L10', so the naming order gets messed up when used with CPT
+// This patch adds consistency to the 'Labrador' when CPT is installed
+
+@PART[labrador-engine]:NEEDS[002_CommunityPartsTitles]:FINAL  { @title = #LOC_Labradoodle_labrador-engine_title-CPT } // RE-B20 "Labrador" Liquid Fuel Engine

--- a/GameData/Labradoodle/Patches/labrador-engine-CPT.cfg
+++ b/GameData/Labradoodle/Patches/labrador-engine-CPT.cfg
@@ -2,4 +2,4 @@
 // In CPT, the 'Poodle' is labeled as 'RE-B10' instead of its stock name 'RE-L10', so the naming order gets messed up when used with CPT
 // This patch adds consistency to the 'Labrador' when CPT is installed
 
-@PART[labrador-engine]:NEEDS[002_CommunityPartsTitles]:FINAL  { @title = #LOC_Labradoodle_labrador-engine_title-CPT } // RE-B20 "Labrador" Liquid Fuel Engine
+@PART[labrador-engine]:FOR[z_Labradoodle]:NEEDS[002_CommunityPartsTitles]	@title = #LOC_Labradoodle_labrador-engine_title_CPT }		// RE-B20 "Labrador" Liquid Fuel Engine


### PR DESCRIPTION
Adds support for Community Part Titles. Fixes the naming ordering of the engines when CPT is installed.
Just a simple patch and update to en-us.cfg